### PR TITLE
prepend deltacould path to prevent errors on require

### DIFF
--- a/server/bin/deltacloudd
+++ b/server/bin/deltacloudd
@@ -16,6 +16,8 @@
 # under the License.
 #
 
+$:.unshift File.join(File.dirname(__FILE__), '..')
+
 require 'rubygems'
 require 'optparse'
 require 'yaml'


### PR DESCRIPTION
This is the reason for the patch:

``` bash
deltacloudd -l

/Users/bulat/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `gem_original_require': no such file to load -- server.rb (LoadError)
    from /Users/bulat/.rvm/rubies/ruby-1.8.7-p352/lib/ruby/site_ruby/1.8/rubygems/custom_require.rb:36:in `require'
    from /Users/bulat/.rvm/gems/ruby-1.8.7-p352/gems/deltacloud-core-0.4.1/bin/deltacloudd:115
    from /Users/bulat/.rvm/gems/ruby-1.8.7-p352/bin/deltacloudd:19:in `load'
    from /Users/bulat/.rvm/gems/ruby-1.8.7-p352/bin/deltacloudd:19
```
