### PR TITLE
vSphere:Fixed json output error in empty public_addresses

### DIFF
--- a/server/lib/deltacloud/drivers/vsphere/vsphere_driver.rb
+++ b/server/lib/deltacloud/drivers/vsphere/vsphere_driver.rb
@@ -178,7 +178,14 @@ module Deltacloud::Drivers::VSphere
           if vm.guest[:net].empty?
             public_addresses = vm.macs.values.collect { |mac_address| InstanceAddress.new(mac_address, :type => :mac) }
           else
-            public_addresses = [InstanceAddress.new(vm.guest[:net].first[:ipAddress].first)]
+            ipaddress = ""
+            vm.guest[:net].each do |net|
+              unless net[:ipAddress].empty?
+                ipaddress = net[:ipAddress].first
+                break
+              end
+            end
+            public_addresses = [InstanceAddress.new(ipaddress)]
           end
           Instance.new(
             :id => properties[:name],


### PR DESCRIPTION
At the specific situation which vm has Network Interface and vmware-tools installed the vm and network interface is down in the vm,
public_addresses response is below.(vSphereESXi5.0)

> > > :public_addresses=>[{:address=>{:type=>:unavailable, :value=>}}]

A json error occurs when execute "to_json" at this response.

So, I changed "vsphere_driver.rb" to get empty value.

Please Check this change.
And, Please merge trunk branch.

Thanks.
Daisuke Ikeda (TIS Inc.)
