### PR TITLE
Rebase and fixup for the 396 networking patchset

### DIFF
--- a/server/lib/deltacloud/collections/instances.rb
+++ b/server/lib/deltacloud/collections/instances.rb
@@ -38,6 +38,9 @@ module Deltacloud::Collections
       if driver.class.has_feature?(:instances, :authentication_key)
         @opts[:keys] = driver.keys(credentials)
       end
+      if driver.has_capability? :networks
+        @opts[:networks] = driver.networks(credentials)
+      end
     end
 
     get '/instances/:id/run' do
@@ -57,7 +60,11 @@ module Deltacloud::Collections
         param :realm_id,     :string, :optional
         param :hwp_id,       :string, :optional
         param :keyname,      :string, :optional
+        param :network_id,   :string, :optional
+        param :subnet_id,    :string, :optional
         control do
+          params.merge!({:network_id => params["network_id"].split("+").first}) unless params["network_id"].empty?
+          params.merge!({:subnet_id => params["network_id"].split("+").last}) unless params["network_id"].empty?
           @instance = driver.create_instance(credentials, params[:image_id], params)
           if @instance.kind_of? Array
             @elements = @instance

--- a/server/lib/deltacloud/collections/networks.rb
+++ b/server/lib/deltacloud/collections/networks.rb
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+module Deltacloud::Collections
+  class Networks < Base
+
+    include Deltacloud::Features
+
+    set :capability, lambda { |m| driver.respond_to? m }
+    check_features :for => lambda { |c, f| driver.class.has_feature?(c, f) }
+
+    get '/networks/new' do
+      respond_to do |format|
+        format.html { haml :"networks/new" }
+      end
+    end
+
+    collection :networks do
+
+      standard_show_operation
+      standard_index_operation
+
+      operation :create, :with_capability => :create_network do
+        param :address_block, :string, :optional
+        param :name,          :string, :optional
+        control do
+          @network = driver.create_network(credentials, { :address_block => params[:address_block]})
+          respond_to do |format|
+            format.xml  { haml :"networks/show" }
+            format.html { haml :"networks/show" }
+            format.json { xml_to_json("networks/show")}
+          end
+        end
+      end
+
+      operation :destroy, :with_capability => :destroy_network do
+        control do
+          driver.destroy_network(credentials, params[:id])
+          status 204
+          respond_to do |format|
+            format.xml
+            format.json
+            format.html { redirect(networks_url) }
+          end
+        end
+      end
+
+    end
+
+  end
+end

--- a/server/lib/deltacloud/collections/subnets.rb
+++ b/server/lib/deltacloud/collections/subnets.rb
@@ -1,0 +1,65 @@
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+module Deltacloud::Collections
+  class Subnets < Base
+
+    include Deltacloud::Features
+
+    set :capability, lambda { |m| driver.respond_to? m }
+    check_features :for => lambda { |c, f| driver.class.has_feature?(c, f) }
+
+    get '/subnets/new' do
+      respond_to do |format|
+        format.html { haml :"subnets/new" }
+      end
+    end
+
+
+    collection :subnets do
+
+      standard_show_operation
+      standard_index_operation
+
+      operation :create, :with_capability => :create_subnet do
+        param :network_id, :string, :required
+        param :address_block,  :string,  :required
+        control do
+          @subnet = driver.create_subnet(credentials, { :network_id => params[:network_id], :address_block => params[:address_block]})
+          respond_to do |format|
+            format.xml  { haml :"subnets/show"}
+            format.html { haml :"subnets/show" }
+            format.json { xml_to_json("subnets/show")}
+          end
+        end
+      end
+
+      operation :destroy, :with_capability => :destroy_subnet do
+        control do
+          driver.destroy_subnet(credentials, params[:id])
+          status 204
+          respond_to do |format|
+            format.xml
+            format.json
+            format.html { redirect(subnets_url) }
+          end
+        end
+      end
+
+    end
+
+  end
+end

--- a/server/lib/deltacloud/drivers/base_driver.rb
+++ b/server/lib/deltacloud/drivers/base_driver.rb
@@ -259,6 +259,13 @@ module Deltacloud
       addresses(credentials, opts).first if has_capability?(:addresses)
     end
 
+    def network(credentials, opts={})
+      networks(credentials, opts).first if has_capability?(:networks)
+    end
+
+    def subnet(credentials, opts={})
+      subnets(credentials, opts).first if has_capability?(:subnets)
+    end
 
     MEMBER_SHOW_METHODS = [ :realm, :image, :instance, :storage_volume, :bucket, :blob,
                             :key, :firewall ] unless defined?(MEMBER_SHOW_METHODS)

--- a/server/lib/deltacloud/drivers/mock/data/networks/net1.yml
+++ b/server/lib/deltacloud/drivers/mock/data/networks/net1.yml
@@ -1,0 +1,9 @@
+---
+:id: net1
+:name: network1
+:subnets:
+- subnet1
+- subnet2
+:address_blocks:
+- 192.168.0.0/16
+:state: UP

--- a/server/lib/deltacloud/drivers/mock/data/networks/net2.yml
+++ b/server/lib/deltacloud/drivers/mock/data/networks/net2.yml
@@ -1,0 +1,9 @@
+---
+:id: net2
+:name: network2
+:subnets:
+- subnet3
+- subnet4
+:address_blocks:
+- 10.0.0.0/8
+:state: UP

--- a/server/lib/deltacloud/drivers/mock/data/subnets/subnet1.yml
+++ b/server/lib/deltacloud/drivers/mock/data/subnets/subnet1.yml
@@ -1,0 +1,6 @@
+---
+:id: subnet1
+:name: subnet1
+:network: net1
+:address_block: 192.168.1.0/24
+:state: UP

--- a/server/lib/deltacloud/drivers/mock/data/subnets/subnet2.yml
+++ b/server/lib/deltacloud/drivers/mock/data/subnets/subnet2.yml
@@ -1,0 +1,6 @@
+---
+:id: subnet2
+:name: subnet2
+:network: net1
+:address_block: 192.168.2.0/24
+:state: UP

--- a/server/lib/deltacloud/drivers/mock/data/subnets/subnet3.yml
+++ b/server/lib/deltacloud/drivers/mock/data/subnets/subnet3.yml
@@ -1,0 +1,6 @@
+---
+:id: subnet3
+:name: subnet3
+:network: net2
+:address_block: 10.1.0.0/16
+:state: UP

--- a/server/lib/deltacloud/drivers/mock/data/subnets/subnet4.yml
+++ b/server/lib/deltacloud/drivers/mock/data/subnets/subnet4.yml
@@ -1,0 +1,6 @@
+---
+:id: subnet4
+:name: subnet4
+:network: net2
+:address_block: 10.2.0.0/16
+:state: UP

--- a/server/lib/deltacloud/models/instance.rb
+++ b/server/lib/deltacloud/models/instance.rb
@@ -34,6 +34,7 @@ module Deltacloud
     attr_accessor :create_image
     attr_accessor :firewalls
     attr_accessor :storage_volumes
+    attr_accessor :network_bindings
 
     def to_hash(context)
       r = {

--- a/server/lib/deltacloud/models/network.rb
+++ b/server/lib/deltacloud/models/network.rb
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The
@@ -12,25 +13,18 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 # License for the specific language governing permissions and limitations
 # under the License.
+module Deltacloud
+class Network < BaseModel
 
-require_relative 'models/base_model'
-require_relative 'models/address'
-require_relative 'models/blob'
-require_relative 'models/bucket'
-require_relative 'models/firewall'
-require_relative 'models/firewall_rule'
-require_relative 'models/hardware_profile'
-require_relative 'models/image'
-require_relative 'models/instance'
-require_relative 'models/instance_address'
-require_relative 'models/instance_profile'
-require_relative 'models/key'
-require_relative 'models/load_balancer'
-require_relative 'models/metric'
-require_relative 'models/provider'
-require_relative 'models/realm'
-require_relative 'models/state_machine'
-require_relative 'models/storage_snapshot'
-require_relative 'models/storage_volume'
-require_relative 'models/network'
-require_relative 'models/subnet'
+  attr_accessor :name
+  attr_accessor :subnets
+  attr_accessor :address_blocks
+  attr_accessor :state
+
+  def initialize(init=nil)
+    super(init)
+    self.subnets = [] unless self.subnets
+  end
+
+end
+end

--- a/server/lib/deltacloud/models/subnet.rb
+++ b/server/lib/deltacloud/models/subnet.rb
@@ -1,3 +1,4 @@
+#
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.  The
@@ -13,24 +14,14 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-require_relative 'models/base_model'
-require_relative 'models/address'
-require_relative 'models/blob'
-require_relative 'models/bucket'
-require_relative 'models/firewall'
-require_relative 'models/firewall_rule'
-require_relative 'models/hardware_profile'
-require_relative 'models/image'
-require_relative 'models/instance'
-require_relative 'models/instance_address'
-require_relative 'models/instance_profile'
-require_relative 'models/key'
-require_relative 'models/load_balancer'
-require_relative 'models/metric'
-require_relative 'models/provider'
-require_relative 'models/realm'
-require_relative 'models/state_machine'
-require_relative 'models/storage_snapshot'
-require_relative 'models/storage_volume'
-require_relative 'models/network'
-require_relative 'models/subnet'
+module Deltacloud
+class Subnet < BaseModel
+
+  attr_accessor :name
+  attr_accessor :network
+  attr_accessor :address_block
+  attr_accessor :state
+  attr_accessor :type
+
+end
+end

--- a/server/views/instances/new.html.haml
+++ b/server/views/instances/new.html.haml
@@ -84,6 +84,15 @@
               %input{ :type => :text, :id => "path#{i}", :name => "path#{i}", :value => ""} Path #{i}
               %input{ :type => "file", :name => "content#{i}", :size => 50 }
 
+        - if driver.has_capability? :networks
+          %div{ 'data-role' => :fieldcontain }
+            %label{ :for => :network, :class => 'ui-input-text'} Network to Launch Instance into:
+            %select{:name => 'network_id', :'data-native-menu' => "true" }
+              %option{ :value => ''} None
+              - @networks.each do |net|
+                - net.subnets.each do |sn|
+                  %option{ :value => "#{net.id}+#{sn}" } #{net.id}+#{sn}
+
     - if !hardware_profiles.empty?
       %div{ 'data-role' => :fieldcontain }
         %h3 Instance profile

--- a/server/views/instances/show.html.haml
+++ b/server/views/instances/show.html.haml
@@ -56,6 +56,15 @@
       -instance.storage_volumes.each do |vol|
         %li
           %a{ :href => storage_volume_url("#{vol.keys.first}"), :'data-ajax' => 'false'}=["#{vol.keys.first}", "#{vol.values.first}"].compact.reject{ |e| e.empty? }.join(' <---> ')
+    - if @instance.network_bindings
+      %li{ :'data-role' => 'list-divider'} Network Bindings
+      -@instance.network_bindings.each do |net_bind|
+        %li
+          %a{ :href => network_url("#{net_bind[:network]}"), :'data-ajax' => 'false'}="Network #{net_bind[:network]}"
+        %li
+          %a{ :href => subnet_url("#{net_bind[:subnet]}"), :'data-ajax' => 'false'}="Subnet #{net_bind[:subnet]}"
+        %li="Address #{net_bind[:ip_address]}"
+        %li
     %li{ :'data-role' => 'list-divider'} Actions
     %li
       %div{ :'data-role' => 'controlgroup', :'data-type' => "horizontal" }

--- a/server/views/networks/index.html.haml
+++ b/server/views/networks/index.html.haml
@@ -1,0 +1,10 @@
+=header "Networks" do
+  %a{ :href => url_for('networks/new'), :'data-icon' => :plus, :'data-role' => :button, :class => 'ui-btn-right'} Create new network
+
+%div{ :'data-role' => :content, :'data-theme' => 'c'}
+  %ul{ :'data-role' => :listview , :'data-inset' => :true, :'data-divider-theme' => 'a'}
+    - @elements.each do |net|
+      %li
+        %a{ :href => network_url(net.id), :'data-ajax' => 'false'}
+          %img{ :class => 'ui-link-thumb', :src => '/images/cloud.png'}
+          %h3=net.id

--- a/server/views/networks/index.xml.haml
+++ b/server/views/networks/index.xml.haml
@@ -1,0 +1,4 @@
+!!!XML
+%networks
+  - @elements.each do |c|
+    = haml :'networks/show', :locals => { :@network => c, :partial => true }

--- a/server/views/networks/index.xml.haml
+++ b/server/views/networks/index.xml.haml
@@ -1,4 +1,4 @@
 !!!XML
 %networks
   - @elements.each do |c|
-    = haml :'networks/show', :locals => { :@network => c, :partial => true }
+    = haml :'networks/show', :locals => { :network => c, :partial => true }

--- a/server/views/networks/new.html.haml
+++ b/server/views/networks/new.html.haml
@@ -1,0 +1,10 @@
+=header "Create new network"
+
+%div{ :'data-role' => :content, :'data-theme' => 'c', :class => 'middle-dialog'}
+  %form{ :action => networks_url, :method => :post}
+    %div{ 'data-role' => :fieldcontain }
+      %p
+        %label{ :for => :address_block} CIDR Address block (optional):
+      %p
+        %input{ :type => :text, :id => :address_block, :name => :address_block, :value => '' }
+    %button{ :type => :submit} Create network

--- a/server/views/networks/show.html.haml
+++ b/server/views/networks/show.html.haml
@@ -1,0 +1,25 @@
+=header "Network"
+=subheader @network.id
+
+%div{ :'data-role' => :content, :'data-theme' => 'c'}
+  %ul{ :'data-role' => :listview , :'data-inset' => :true, :'data-divider-theme' => 'd'}
+    %li{ :'data-role' => 'list-divider'} Identifier
+    %li
+      %p{ :'data-role' => 'fieldcontain'}=@network.id
+    %li{ :'data-role' => 'list-divider'} Name
+    %li
+      %p{ :'data-role' => 'fieldcontain'}=@network.name
+    %li{ :'data-role' => 'list-divider'} State
+    %li
+      %p{ :'data-role' => 'fieldcontain'}=@network.state
+    %li{ :'data-role' => 'list-divider'} Address Blocks
+    %li
+      %p{ :'data-role' => 'fieldcontain'}=(@network.address_blocks ? @network.address_blocks.join(",") : nil)
+    %li{ :'data-role' => 'list-divider'} Subnets
+    -@network.subnets.each do |sn|
+      %li
+        %a{ :href => subnet_url(sn.strip), :'data-ajax'=>'false' }=sn
+    %li{ :'data-role' => 'list-divider'} Actions
+    %li
+      %div{ :'data-role' => 'controlgroup', :'data-type' => "horizontal" }
+        =link_to_action "Destroy", destroy_network_url(@network.id), :delete

--- a/server/views/networks/show.xml.haml
+++ b/server/views/networks/show.xml.haml
@@ -1,0 +1,15 @@
+- unless defined?(partial)
+  !!! XML
+%network{ :href => network_url(@network.id), :id => @network.id }
+  %name=@network.name
+  %state<
+    =@network.state
+  %address_blocks
+    - @network.address_blocks.each do |addr_block|
+      %address_block=addr_block
+  %subnets
+    - (@network.subnets || []).each do |subnet|
+      %subnet{:href => subnet_url(subnet), :id=>subnet}
+  %actions
+    - if driver.respond_to?(:destroy_network)
+      %link{ :rel => "destroy", :method => "delete", :href => destroy_network_url(@network.id)}

--- a/server/views/networks/show.xml.haml
+++ b/server/views/networks/show.xml.haml
@@ -1,15 +1,15 @@
 - unless defined?(partial)
   !!! XML
-%network{ :href => network_url(@network.id), :id => @network.id }
-  %name=@network.name
+%network{ :href => network_url(network.id), :id => network.id }
+  %name=network.name
   %state<
-    =@network.state
+    =network.state
   %address_blocks
-    - @network.address_blocks.each do |addr_block|
+    - network.address_blocks.each do |addr_block|
       %address_block=addr_block
   %subnets
-    - (@network.subnets || []).each do |subnet|
+    - (network.subnets || []).each do |subnet|
       %subnet{:href => subnet_url(subnet), :id=>subnet}
   %actions
     - if driver.respond_to?(:destroy_network)
-      %link{ :rel => "destroy", :method => "delete", :href => destroy_network_url(@network.id)}
+      %link{ :rel => "destroy", :method => "delete", :href => destroy_network_url(network.id)}

--- a/server/views/subnets/index.html.haml
+++ b/server/views/subnets/index.html.haml
@@ -1,0 +1,10 @@
+=header "Subnets" do
+  %a{ :href => url_for('subnets/new'), :'data-icon' => :plus, :'data-role' => :button, :class => 'ui-btn-right'} Create new subnet
+
+%div{ :'data-role' => :content, :'data-theme' => 'c'}
+  %ul{ :'data-role' => :listview , :'data-inset' => :true, :'data-divider-theme' => 'a'}
+    - @elements.each do |subnet|
+      %li
+        %a{ :href => subnet_url(subnet.id), :'data-ajax' => 'false'}
+          %img{ :class => 'ui-link-thumb', :src => '/images/cloud.png'}
+          %h3=subnet.id

--- a/server/views/subnets/index.xml.haml
+++ b/server/views/subnets/index.xml.haml
@@ -1,4 +1,4 @@
 !!!XML
 %subnets
   - @elements.each do |c|
-    = haml :'subnets/show', :locals => { :@subnet => c, :partial => true }
+    = haml :'subnets/show', :locals => { :subnet => c, :partial => true }

--- a/server/views/subnets/index.xml.haml
+++ b/server/views/subnets/index.xml.haml
@@ -1,0 +1,4 @@
+!!!XML
+%subnets
+  - @elements.each do |c|
+    = haml :'subnets/show', :locals => { :@subnet => c, :partial => true }

--- a/server/views/subnets/new.html.haml
+++ b/server/views/subnets/new.html.haml
@@ -1,0 +1,14 @@
+=header "Create new subnet"
+
+%div{ :'data-role' => :content, :'data-theme' => 'c', :class => 'middle-dialog'}
+  %form{ :action => subnets_url, :method => :post}
+    %div{ 'data-role' => :fieldcontain }
+      %p
+        %label{ :for => :network_id} Network ID:
+      %p
+        %input{ :type => :text, :id => :network_id, :name => :network_id, :value => '' }
+      %p
+        %label{ :for => :address_block} CIDR Address block:
+      %p
+        %input{ :type => :text, :id => :address_block, :name => :address_block, :value => '' }
+    %button{ :type => :submit} Create subnet

--- a/server/views/subnets/show.html.haml
+++ b/server/views/subnets/show.html.haml
@@ -1,0 +1,24 @@
+=header "Subnet"
+=subheader @subnet.id
+
+%div{ :'data-role' => :content, :'data-theme' => 'c'}
+  %ul{ :'data-role' => :listview , :'data-inset' => :true, :'data-divider-theme' => 'd'}
+    %li{ :'data-role' => 'list-divider'} Identifier
+    %li
+      %p{ :'data-role' => 'fieldcontain'}=@subnet.id
+    %li{ :'data-role' => 'list-divider'} Name
+    %li
+      %p{ :'data-role' => 'fieldcontain'}=@subnet.name
+    %li{ :'data-role' => 'list-divider'} Network
+    %li
+      %a{ :href => network_url(@subnet.network.strip), :'data-ajax'=>'false' }=@subnet.network
+    %li{ :'data-role' => 'list-divider'} State
+    %li
+      %p{ :'data-role' => 'fieldcontain'}=@subnet.state
+    %li{ :'data-role' => 'list-divider'} Address Block
+    %li
+      %p{ :'data-role' => 'fieldcontain'}=(@subnet.address_block ? @subnet.address_block : nil)
+    %li{ :'data-role' => 'list-divider'} Actions
+    %li
+      %div{ :'data-role' => 'controlgroup', :'data-type' => "horizontal" }
+        =link_to_action "Destroy", destroy_subnet_url(@subnet.id), :delete

--- a/server/views/subnets/show.xml.haml
+++ b/server/views/subnets/show.xml.haml
@@ -1,13 +1,13 @@
 - unless defined?(partial)
   !!! XML
-%subnet{ :href => subnet_url(@subnet.id), :id => @subnet.id }
-  %name=@subnet.name
+%subnet{ :href => subnet_url(subnet.id), :id => subnet.id }
+  %name=subnet.name
   %state<
-    =@subnet.state
+    =subnet.state
   %address_block
-    =@subnet.address_block
+    =subnet.address_block
   %network
-    =@subnet.network
+    =subnet.network
   %actions
     - if driver.respond_to?(:destroy_subnet)
-      %link{ :rel => "destroy", :method => "delete", :href => destroy_subnet_url(@subnet.id)}
+      %link{ :rel => "destroy", :method => "delete", :href => destroy_subnet_url(subnet.id)}

--- a/server/views/subnets/show.xml.haml
+++ b/server/views/subnets/show.xml.haml
@@ -1,0 +1,13 @@
+- unless defined?(partial)
+  !!! XML
+%subnet{ :href => subnet_url(@subnet.id), :id => @subnet.id }
+  %name=@subnet.name
+  %state<
+    =@subnet.state
+  %address_block
+    =@subnet.address_block
+  %network
+    =@subnet.network
+  %actions
+    - if driver.respond_to?(:destroy_subnet)
+      %link{ :rel => "destroy", :method => "delete", :href => destroy_subnet_url(@subnet.id)}


### PR DESCRIPTION
Recent changes in the master made the networking patches sent by @marios[1](http://tracker.deltacloud.org/set/396) incompatible.

This is a rebase of those patches against the master plus a few fixes so that listing networks and subnets as application/xml works properly.
